### PR TITLE
Fix test for funcfiletrace on later zshdb in ok4zshdb.sh (Closes: #9)

### DIFF
--- a/test/zsh/ok4zshdb.sh
+++ b/test/zsh/ok4zshdb.sh
@@ -4,8 +4,8 @@ PS4='%(%x:%I): [%?]
 '
 
 second_fn() {
-  decls=$(declare -p)
-  if [[ $decls != *funcfiletrace* ]] ; then
+  zmodload zsh/parameter
+  if ! (( ${+funcfiletrace} )) ; then
     print "Looks like you don't have funcfiletrace."
     print "We need a zsh new enough which has that."
     exit 10


### PR DESCRIPTION
funcfiletrace is no longer listed in the output of declare -p.