### PR TITLE
Fix issue #24: use correct tty for prompt/commands

### DIFF
--- a/lib/processor.sh
+++ b/lib/processor.sh
@@ -126,7 +126,7 @@ function _Dbg_process_commands {
           ((_Dbg_cmd_num++))
           if ((0 == _Dbg_in_vared)) && [[ -t $_Dbg_fdi ]]; then
               _Dbg_in_vared=1
-              vared -e -h -p "$_Dbg_prompt" line <&${_Dbg_fdi} || break
+              vared -e -h -p "$_Dbg_prompt" -t "$_Dbg_tty" line || break
               _Dbg_in_vared=0
           else
               if ((1 == _Dbg_in_vared)) ; then


### PR DESCRIPTION
Using the handy `-t <tty>` option for `vared`. Confirmed that `$_Dbg_tty` is always set, i.e. both when zshdb is invoked with the -tty option and when it is not.