### PR TITLE
A few more bugfixes

### DIFF
--- a/command/eval.sh
+++ b/command/eval.sh
@@ -68,7 +68,7 @@ typeset -i _Dbg_show_eval_rc; _Dbg_show_eval_rc=1
 
 _Dbg_do_eval() {
 
-    print "0=$_Dbg_dollar_0" > "$_Dbg_evalfile"
+    print "0=\"$_Dbg_dollar_0\"" > "$_Dbg_evalfile"
     print ". ${_Dbg_libdir}/lib/set-d-vars.sh" >> "$_Dbg_evalfile"
     print '_Dbg_rc=$?' >> "$_Dbg_evalfile"
 

--- a/command/source.sh
+++ b/command/source.sh
@@ -36,9 +36,9 @@ _Dbg_do_source() {
 
     typeset filename
     _Dbg_tilde_expand_filename "$1"
-    if [[ -r $filename ]] || [[ "$filename" == '/dev/stdin' ]] ; then
+    if [[ -r "$filename" ]] || [[ "$filename" == '/dev/stdin' ]] ; then
         # Redirect std input to new file and save new descriptor number
-        exec {_Dbg_fdi}< $filename
+        exec {_Dbg_fdi}< "$filename"
         # Save descriptor number and assocated file name.
         _Dbg_fd+=($_Dbg_fdi)
         _Dbg_cmdfile+=("$filename")

--- a/lib/file.sh
+++ b/lib/file.sh
@@ -44,8 +44,7 @@ _Dbg_adjust_filename() {
 # The result will be in variable $filename which is assumed to be
 # local'd by the caller
 _Dbg_tilde_expand_filename() {
-  typeset cmd="filename=$(expr $1)"
-  eval "$cmd"
+  filename="${1/#\~/$HOME}"
   [[ -r "$filename" ]]
 }
 

--- a/lib/tty.sh
+++ b/lib/tty.sh
@@ -60,8 +60,8 @@ function _Dbg_set_tty {
   fi
   typeset -i _Dbg_new_fd
   if _Dbg_open_if_tty $1 ; then
-      _Dbg_fdi=$_Dbg_new_fd
-      _Dbg_fd[-1]=$_Dbg_fdi
+      _Dbg_fd=($_Dbg_new_fd "${_Dbg_fd[@]}")
+      _Dbg_fdi=$_Dbg_fd[-1]
   else
       _Dbg_errmsg "$1 is not reputed to be a tty."
   fi


### PR DESCRIPTION
The debugger commands file supplied with the -x option was not being executed at all. However, the string passed as -x was being unsafely eval'ed (as shell code, not debugger commands) as part of `_Dbg_tilde_expand_filename`. 

The function `_Dbg_set_tty` was resetting the array `$_Dbg_fd` after loading in the -x file which was preventing the -x file from ever being executed.