### PR TITLE
add the return code of the evaluated expression

### DIFF
--- a/command/eval.sh
+++ b/command/eval.sh
@@ -117,6 +117,7 @@ _Dbg_do_eval() {
         _Dbg_set_dol_q $_Dbg_debugged_exit_code
         . $_Dbg_evalfile
     fi
+    _Dbg_rc=$?
     (( _Dbg_show_eval_rc )) && _Dbg_msg "\$? is $_Dbg_rc"
     # We've reset some variables like IFS and PS4 to make eval look
     # like they were before debugger entry - so reset them now.


### PR DESCRIPTION
```
zshdb<0> l
  1:    #!/bin/zsh -f
  2:
  3: => if test -z "$a" ; then
  4:        echo "a is not set"
  5:    else
  6:        echo "a is set to $a"
  7:    fi
zshdb<0> ev?
eval: test -z "$a"
$? is 0
zshdb<0> ev a=22
$? is 0
zshdb<0> ev?
eval: test -z "$a"
$? is 1
zshdb<0>
```