### PR TITLE
add missing info_sub files to Makefile setup

### DIFF
--- a/command/info_sub/Makefile.am
+++ b/command/info_sub/Makefile.am
@@ -1,12 +1,6 @@
 MOSTLYCLEANFILES = *.orig *.rej
 
 pkgdatadir        = ${datadir}/@PACKAGE@/command/info_sub
-pkgdata_DATA =         \
-	breakpoints.sh \
-	files.sh       \
-	functions.sh   \
-	program.sh     \
-	variables.sh   \
-	warranty.sh
+pkgdata_DATA = $(wildcard *.sh)
 
 EXTRA_DIST = $(pkgdata_DATA)


### PR DESCRIPTION
Closes https://github.com/rocky/zshdb/issues/40

File line.sh and a few more info_sub commands were not installed with "make install".