### PR TITLE
Make `a_fg` and `a_bg` local variables to avoid side-effects

### DIFF
--- a/zterm-background.sh
+++ b/zterm-background.sh
@@ -61,6 +61,7 @@ get_default_colorfgbg() {
 is_dark_rgb() {
   typeset fg_r fg_g fg_b
   typeset bg_r bg_g bg_b
+  typeset a_fg a_bg
   fg_r=$1
   fg_g=$2
   fg_b=$3


### PR DESCRIPTION
Equivalent of bashdb's https://github.com/BashSupport-Pro/bashdb/commit/7040df6523883626c0207ba9a3cc65bf873f5164

This PR add\s the two missing variables declarations to make them local.