### PR TITLE
Add missing info subcommands "program" and "signals" to the list of available subcommands

### DIFF
--- a/command/info.sh
+++ b/command/info.sh
@@ -50,7 +50,7 @@ _Dbg_do_info_internal() {
     typeset label=$2
 
     # Warranty is omitted below.
-    typeset subcmds='breakpoints display files functions line source stack variables'
+    typeset subcmds='breakpoints display files functions line program signals source stack variables'
 
     if [[ -z $info_cmd ]] ; then
         typeset thing


### PR DESCRIPTION
`info program` and `info signals` were missing in the output of `info unknown-command`

`info.sh` contains this, I wasn't sure if it's supposed to be removed or if `info handle` should be added as alias:
```
        #       h | ha | han | hand | handl | handle | \
        #           si | sig | sign | signa | signal | signals )
        #         _Dbg_info_signals
        #         return
        #     ;;
```