### PR TITLE
Support "info args" for the top-level frame

### DIFF
--- a/command/info.sh
+++ b/command/info.sh
@@ -50,7 +50,7 @@ _Dbg_do_info_internal() {
     typeset label=$2
 
     # Warranty is omitted below.
-    typeset subcmds='breakpoints display files functions line source stack variables'
+    typeset subcmds='args breakpoints display files functions line source stack variables'
 
     if [[ -z $info_cmd ]] ; then
         typeset thing
@@ -64,10 +64,6 @@ _Dbg_do_info_internal() {
     fi
 
     case $info_cmd in
-	#         a | ar | arg | args )
-	#               _Dbg_do_info_args 3
-	#             return 0
-	#             ;;
         #       h | ha | han | hand | handl | handle | \
         #           si | sig | sign | signa | signal | signals )
         #         _Dbg_info_signals

--- a/command/info_sub/args.sh
+++ b/command/info_sub/args.sh
@@ -1,0 +1,53 @@
+# -*- shell-script -*-
+# "info args" debugger command
+#
+#   Copyright (C) 2023 Rocky Bernstein
+#   <rocky@gnu.org>
+#
+#   This program is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation; either version 2, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program; see the file COPYING.  If not, write to
+#   the Free Software Foundation, 59 Temple Place, Suite 330, Boston,
+#   MA 02111 USA.
+
+# Print info args. Like GDB's "info args"
+# Unfortunately, Zsh doesn't have an equivalent for "BASH_ARGC" and "BASH_ARGV".
+# It's only possible to provide the arguments for the top frame.
+
+_Dbg_help_add_sub info args \
+    "**info args**
+
+Show argument variables of the current stack frame.
+
+See also:
+---------
+
+**backtrace**." 1
+
+_Dbg_do_info_args() {
+    if (($# != 1)); then
+        _Dbg_errmsg "Arguments are not supported"
+        return 1
+    fi
+
+    # Print out parameter list.
+    typeset -i arg_count=${#_Dbg_frame_argv[@]}
+    if ((arg_count == 0)); then
+        _Dbg_msg "Argument count is 0 for this call."
+    else
+        typeset -i i
+        for ((i = 1; i <= arg_count; i++)); do
+            _Dbg_printf "$%d = %s" $i "${_Dbg_frame_argv[$i - 1]}"
+        done
+    fi
+    return 0
+}

--- a/lib/hook.sh
+++ b/lib/hook.sh
@@ -31,6 +31,9 @@ typeset -i _Dbg_program_exit_code=0
 # Number of statements to skip before entering the debugger if greater than 0
 typeset -i _Dbg_skip_ignore=0
 
+# tracking of frame arguments, contains the arguments passed to the last call
+typeset -a _Dbg_frame_argv=()
+
 # This is the main hook routine that gets called before every statement.
 # It's the function called via trap DEBUG.
 function _Dbg_trap_handler {
@@ -55,9 +58,7 @@ function _Dbg_trap_handler {
 
     _Dbg_dollar_0=$1
     shift
-    # Populate _Dbg_arg with $1, $2, etc.
-    typeset -a _Dbg_arg
-    _Dbg_arg=($@)   # Does this require shword split off?
+    _Dbg_frame_argv=($@)
 
     typeset -i _Dbg_skipping_fn
     ((_Dbg_skipping_fn =


### PR DESCRIPTION
This PR adds support for `info args`.

AFAIK it's not possible to retrieve the arguments passed to previous frames on the call stack. Zshdb doesn't have an equivalent of `$BASH_ARGC` and `$BASH_ARGV`. 
For BashSupport Pro, I at least wanted to support arguments for the top frame instead of showing nothing at all.

I couldn't find a solution to emulate this with zshdb's hook function because the DEBUG trap is only called on entry and there's no other trap handler when a function is exited. Without a return handler it's not possible to remove the exited function's arguments from the array used to emulate `$BASH_ARGC`/`$BASH_ARGV`.

I removed `_Dbg_arg` from hook.sh because it's unused and could be confusing with the new variable.

If this PR seems like the right direction, then I'll try to add tests :)