### PR TITLE
Improve handling of info subcommands and fix support for `info stack`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,6 +15,7 @@
 #   the Free Software Foundation, 59 Temple Place, Suite 330, Boston,
 #   MA 02111 USA.
 
+LANG    = C
 RUBY   ?= ruby
 GIT2CL ?= git2cl
 

--- a/command/info.sh
+++ b/command/info.sh
@@ -35,7 +35,7 @@ typeset -a _Dbg_info_subcmds
 _Dbg_info_subcmds=( breakpoints display files "function" "line" program source stack variables )
 
 # Load in "info" subcommands
-for _Dbg_file in ${_Dbg_libdir}/command/info_sub/*.sh ; do
+for _Dbg_file in "${_Dbg_libdir}"/command/info_sub/*.sh ; do
     source "$_Dbg_file"
 done
 _Dbg_complete_level_1_data[info]=$(echo ${(kM)_Dbg_debugger_info_commands})

--- a/command/info.sh
+++ b/command/info.sh
@@ -31,9 +31,6 @@ typeset -A _Dbg_command_help_info
 
 _Dbg_help_add info ''  # Help routine is elsewhere
 
-typeset -a _Dbg_info_subcmds
-_Dbg_info_subcmds=( breakpoints display files "function" "line" program source stack variables )
-
 # Load in "info" subcommands
 for _Dbg_file in "${_Dbg_libdir}"/command/info_sub/*.sh ; do
     source "$_Dbg_file"
@@ -46,47 +43,46 @@ _Dbg_do_info() {
 }
 
 _Dbg_do_info_internal() {
-    typeset info_cmd="$1"
-    typeset label=$2
+    if (($# > 0)) ; then
+        typeset subcmd="$1"
+        shift
 
-    # Warranty is omitted below.
-    typeset subcmds='args breakpoints display files functions line source stack variables'
+        if [[ -n ${_Dbg_debugger_info_commands[$subcmd]} ]] ; then
+            ${_Dbg_debugger_info_commands[$subcmd]} "$@"
+            return $?
+        else
+            # Look for a unique abbreviation
+            typeset -i count=0
+            typeset list; list="${(k)_Dbg_debugger_info_commands[@]}"
+            for try in $list ; do
+                if [[ $try =~ ^$subcmd ]] ; then
+                    subcmd=$try
+                    ((count++))
+                fi
+            done
+            ((found=(count==1)))
+        fi
+        if ((found)); then
+            ${_Dbg_debugger_info_commands[$subcmd]} "$@"
+            return $?
+        fi
 
-    if [[ -z $info_cmd ]] ; then
-        typeset thing
-        for thing in $subcmds ; do
-            _Dbg_do_info $thing 1
-        done
-        return 0
-    elif [[ -n ${_Dbg_debugger_info_commands[$info_cmd]} ]] ; then
-        ${_Dbg_debugger_info_commands[$info_cmd]} $label "$@"
-        return $?
+        _Dbg_errmsg "Unknown info subcommand: $subcmd"
+        msg=_Dbg_errmsg
+    else
+        msg=_Dbg_msg
     fi
 
-    case $info_cmd in
-        #       h | ha | han | hand | handl | handle | \
-        #           si | sig | sign | signa | signal | signals )
-        #         _Dbg_info_signals
-        #         return
-        #     ;;
-
-        st | sta | stac | stack )
-            _Dbg_do_backtrace 1 $@
-            return 0
-            ;;
-
-        #       te | ter | term | termi | termin | termina | terminal | tt | tty )
-        #     _Dbg_msg "tty: $_Dbg_tty"
-        #     return;
-        #     ;;
-
-        *)
-            _Dbg_errmsg "Unknown info subcommand: $info_cmd"
-            _Dbg_errmsg "Info subcommands are:"
-            typeset -a list; list=(${subcmds[@]})
-            _Dbg_list_columns '  ' _Dbg_errmsg
-            return -1
-    esac
+    typeset -a list
+    list=(${(k)_Dbg_debugger_info_commands[@]})
+    sort_list 0 ${#list[@]}-1
+    typeset -i width; ((width=_Dbg_set_linewidth-5))
+    typeset -a columnized=(); columnize $width
+    typeset -i i
+    $msg "Info subcommands are:"
+    for ((i=0; i<${#columnized[@]}; i++)) ; do
+        $msg "  ${columnized[i]}"
+    done
 }
 
 _Dbg_alias_add i info

--- a/command/info_sub/args.sh
+++ b/command/info_sub/args.sh
@@ -34,7 +34,7 @@ See also:
 **backtrace**." 1
 
 _Dbg_do_info_args() {
-    if (($# != 1)); then
+    if (($# != 0)); then
         _Dbg_errmsg "Arguments are not supported"
         return 1
     fi

--- a/command/info_sub/breakpoints.sh
+++ b/command/info_sub/breakpoints.sh
@@ -67,8 +67,8 @@ _Dbg_complete_level_2_data[info_breakpoints]='-a_Dbg_info_breakpoints_complete'
 
 _Dbg_do_info_breakpoints() {
 
-    if (( $# >= 3  )) ; then
-	typeset brkpt_num=$3
+    if (( $# >= 1 )) ; then
+	typeset brkpt_num=$1
 	if [[ $brkpt_num != [0-9]* ]] ; then
             _Dbg_errmsg "Bad breakpoint number $brkpt_num."
 	elif [[ -z ${_Dbg_brkpt_file[$brkpt_num]} ]] ; then

--- a/command/info_sub/functions.sh
+++ b/command/info_sub/functions.sh
@@ -32,13 +32,6 @@ Examples:
 ' 1
 
 _Dbg_do_info_functions() {
-    # Remove "functions" or "xx functions"
-    if [[ "$1" != "functions" ]] ; then
-	shift
-    fi
-    if [[ "$1" == "functions" ]]; then
-	shift
-    fi
-    _Dbg_do_list_typeset_attr '+f' $@
+     _Dbg_do_list_typeset_attr '+f' "$@"
     return 0
 }

--- a/command/info_sub/stack.sh
+++ b/command/info_sub/stack.sh
@@ -22,5 +22,5 @@ _Dbg_help_add_sub info stack '
 ' 1
 
 _Dbg_do_info_stack() {
-    _Dbg_do_backtrace 1 $@
+    _Dbg_do_backtrace "$@"
 }

--- a/command/info_sub/stack.sh
+++ b/command/info_sub/stack.sh
@@ -1,0 +1,26 @@
+# -*- shell-script -*-
+# "info stack" debugger command
+#
+#   Copyright (C) 2023 Rocky Bernstein rocky@gnu.org
+#
+#   zshdb is free software; you can redistribute it and/or modify it under
+#   the terms of the GNU General Public License as published by the Free
+#   Software Foundation; either version 2, or (at your option) any later
+#   version.
+#
+#   zshdb is distributed in the hope that it will be useful, but WITHOUT ANY
+#   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#   for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with zshdb; see the file COPYING.  If not, write to the Free Software
+#   Foundation, 59 Temple Place, Suite 330, Boston, MA 02111 USA.
+
+_Dbg_help_add_sub info stack '
+**info stack**
+' 1
+
+_Dbg_do_info_stack() {
+    _Dbg_do_backtrace 1 $@
+}

--- a/command/info_sub/variables.sh
+++ b/command/info_sub/variables.sh
@@ -41,8 +41,8 @@ typeset _Dbg_info_var_attrs="array, export, fixed, float, function, hash, intege
 _Dbg_do_info_variables() {
     if (($# > 1)) ; then
         typeset kind="$1"
-	# Remove "info variables xxx"
-        shift; shift; shift
+        shift
+
         case "$kind" in
             a | ar | arr | arra | array | arrays )
                 _Dbg_do_list_typeset_attr '+a' $@


### PR DESCRIPTION
This PR improves the info command and handling of its subcommands.

- [1ae1b53c9eb2cabcf8c05b4c452fadca1b01ba86](https://github.com/rocky/zshdb/pull/51/commits/52f19d6f05f328abe73466bd55f587370263eaac): sync handling of info subcommands with bashdb. Instead of maintaining two lists of subcommands (which were out of sync again), the code now relies on the array `_Dbg_debugger_info_commands`, which is populated when the info subcommand files are sourced. The code also takes care of the command abbreviations (as in bashdb), so that `info sta` is treated as `info stack`. The code was copied from bashdb and adjusted for Zsh. Before this change the invocation of `info` called all subcommands, which is unexpected (and was probably added for debugging, I think).
- The last two commits move the code of `info stack` into a subcommand file and remove the limitation to only one stack frame. I'm not sure why anyone would like to only see the top frame of the stack. It seems to be very old code, so I changed it to work in the same way as bashdb. See below for an before/after comparison.

The original code passed a `$label` arg to the sub command, it was set to `typeset label=$2` and the sub commands were then invoked with `${_Dbg_debugger_info_commands[$info_cmd]} $label "$@"`. If I understand the code correctly, then this turned `info variables integer` into `${_Dbg_debugger_info_commands["variables"]} "integer" "variables" "integer"`. With this PR info sub commands are invoked without the name of the subcommand. Several sub command source files were adjusted to use the new argument values.

To Do:
- [ ] I haven't added tests yet. I'll also have to wait for this PRs CI to see if tests are failing.

`info stack` before this PR:
```
zshdb<2> info stack
->0 in file `/home/jansorg/test.zsh' at line 4
```

`info stack` with this PR:
```
zshdb<2> info stack
->0 in file `/home/jansorg/test.zsh' at line 4
##1 inner called from file `/home/jansorg/test.zsh' at line 8
##2 outer called from file `/home/jansorg/test.zsh' at line 11
##3 /home/jansorg/test.zsh called from file `./zshdb' at line 141
```