### PR TITLE
Fix tests after changes to `info args`

### DIFF
--- a/command/info_sub/args.sh
+++ b/command/info_sub/args.sh
@@ -40,13 +40,13 @@ _Dbg_do_info_args() {
     fi
 
     # Print out parameter list.
-    typeset -i arg_count=${#_Dbg_frame_argv[@]}
+    typeset -i arg_count=${#_Dbg_arg[@]}
     if ((arg_count == 0)); then
         _Dbg_msg "Argument count is 0 for this call."
     else
         typeset -i i
         for ((i = 1; i <= arg_count; i++)); do
-            _Dbg_printf "$%d = %s" $i "${_Dbg_frame_argv[$i - 1]}"
+            _Dbg_printf "$%d = %s" $i "${_Dbg_arg[$i - 1]}"
         done
     fi
     return 0

--- a/lib/hook.sh
+++ b/lib/hook.sh
@@ -31,9 +31,6 @@ typeset -i _Dbg_program_exit_code=0
 # Number of statements to skip before entering the debugger if greater than 0
 typeset -i _Dbg_skip_ignore=0
 
-# tracking of frame arguments, contains the arguments passed to the last call
-typeset -a _Dbg_frame_argv=()
-
 # This is the main hook routine that gets called before every statement.
 # It's the function called via trap DEBUG.
 function _Dbg_trap_handler {
@@ -58,7 +55,9 @@ function _Dbg_trap_handler {
 
     _Dbg_dollar_0=$1
     shift
-    _Dbg_frame_argv=($@)
+    # Populate _Dbg_arg with $1, $2, etc.
+    typeset -a _Dbg_arg
+    _Dbg_arg=($@)   # Does this require shword split off?
 
     typeset -i _Dbg_skipping_fn
     ((_Dbg_skipping_fn =

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -5,3 +5,5 @@ SUBDIRS = data example unit integration zsh
 
 MAINTAINERCLEANFILES = *.check
 EXTRA_DIST = README.md
+
+LANG = C


### PR DESCRIPTION
- My machine is using a German locale. Because tests rely on the English text `not a tty`, this PR enforces to use the default locale (which should be English)
- This PR changes the last changes made to the implementation to `info args` to make test `bug-args` pass.

On my machine a few more tests are failing, but tests were also failing before my changes to `info args`. Let's see what CI is going to say...