### PR TITLE
Fix line count calculation for files which are loaded multiple times

### DIFF
--- a/command/load.sh
+++ b/command/load.sh
@@ -47,7 +47,7 @@ _Dbg_do_load() {
 	    fi
 	done
 
-	_Dbg_readin "$full_filename"
+	_Dbg_readin_if_new "$full_filename"
 	_Dbg_msg "File $full_filename loaded."
     else
 	_Dbg_errmsg "Couldn't resolve or read $filename"

--- a/configure.ac
+++ b/configure.ac
@@ -198,5 +198,7 @@ AC_CONFIG_FILES([test/unit/test-tty.sh],
 		[chmod +x test/unit/test-tty.sh])
 AC_CONFIG_FILES([test/unit/test-validate.sh],
 		[chmod +x test/unit/test-validate.sh])
+AC_CONFIG_FILES([test/unit/test-lib-maxline.sh],
+		[chmod +x test/unit/test-lib-maxline.sh])
 
 AC_OUTPUT

--- a/test/unit/.gitignore
+++ b/test/unit/.gitignore
@@ -19,6 +19,7 @@
 /test-lib-eval.sh
 /test-lib-shell.sh
 /test-lib.eval.sh
+/test-lib-maxline.sh
 /test-msg.sh
 /test-pre.sh
 /test-run.sh

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -5,6 +5,7 @@ COMBINED_TESTS= \
 	test-columns.sh        \
 	test-dbg-opts.sh       \
 	test-lib-eval.sh       \
+	test-lib-maxline.sh    \
 	test-examine.sh        \
 	test-file.sh           \
 	test-filecache.sh      \

--- a/test/unit/test-lib-maxline.sh.in
+++ b/test/unit/test-lib-maxline.sh.in
@@ -1,0 +1,49 @@
+#!@SH_PROG@
+# -*- shell-script -*-
+
+test_get_maxline() {
+    typeset fileOne="$SHUNIT_TMPDIR/file-one"
+    typeset fileTwo="$SHUNIT_TMPDIR/file-two"
+    typeset fileThree="$SHUNIT_TMPDIR/file-three"
+    typeset fileFour="$SHUNIT_TMPDIR/file-four"
+
+    echo -e "one" > "$fileOne"
+    echo -e "one\ntwo" > "$fileTwo"
+    echo -e "one\ntwo\nthree" > "$fileThree"
+    echo -e "one\ntwo\nthree\nfour" > "$fileFour"
+
+    _Dbg_do_load "$fileOne"
+    _Dbg_do_load "$fileOne"
+    _Dbg_do_load "$fileTwo"
+    _Dbg_do_load "$fileTwo"
+    _Dbg_do_load "$fileThree"
+    _Dbg_do_load "$fileThree"
+    _Dbg_do_load "$fileFour"
+    _Dbg_do_load "$fileFour"
+
+    assertEquals '1' "$(_Dbg_get_maxline "$fileOne")"
+    assertEquals '2' "$(_Dbg_get_maxline "$fileTwo")"
+    assertEquals '3' "$(_Dbg_get_maxline "$fileThree")"
+    assertEquals '4' "$(_Dbg_get_maxline "$fileFour")"
+}
+
+if [ @abs_top_srcdir@ = '' ] ; then
+  echo "Something is wrong abs_top_srcdir is not set."
+ exit 1
+fi
+
+abs_top_srcdir=@abs_top_srcdir@
+# Make sure @top_abs_srcdir@ has a trailing slash
+abs_top_srcdir=${abs_top_srcdir%%/}/
+. ${abs_top_srcdir}test/unit/helper.sh
+. ${abs_top_srcdir}/lib/help.sh
+. ${abs_top_srcdir}/lib/msg.sh
+. ${abs_top_srcdir}/dbg-pre.sh
+. ${abs_top_srcdir}/lib/filecache.sh
+. ${abs_top_srcdir}lib/file.sh
+. ${abs_top_srcdir}/command/load.sh
+set -- # reset $# so shunit2 doesn't get confused.
+
+SHUNIT_PARENT=$0
+
+[[ @CMDLINE_INVOKED@ ]] && . ${shunit_file}


### PR DESCRIPTION
In BashSupport Pro, some breakpoints could not be enabled because zshdb insisted that the file does not have that many lines.

In BashSupport Pro some files were loaded more than once with the `load` command. The `load` command did not support this.
This PR adds a test and fixes the `load` command.
