### PR TITLE
wip: Test for prompt after stepping out of a subshell

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -118,6 +118,8 @@ AC_CONFIG_FILES([test/integration/test-bugIFS2],
                 [chmod +x test/integration/test-bugIFS2])
 AC_CONFIG_FILES([test/integration/test-bug-ksharrays],
                 [chmod +x test/integration/test-bug-ksharrays])
+AC_CONFIG_FILES([test/integration/test-bug-step-subshell],
+                [chmod +x test/integration/test-bug-step-subshell])
 AC_CONFIG_FILES([test/integration/test-condition],
                 [chmod +x test/integration/test-condition])
 AC_CONFIG_FILES([test/integration/test-debug],

--- a/test/data/bug-step-subshell.cmd
+++ b/test/data/bug-step-subshell.cmd
@@ -1,0 +1,10 @@
+# step into subshell
+step
+# execute commands inside subshell
+info args
+info args
+eval? echo \$_Dbg_prompt
+# step out of subshell
+step
+eval? echo \$_Dbg_prompt
+quit

--- a/test/data/bug-step-subshell.right
+++ b/test/data/bug-step-subshell.right
@@ -1,0 +1,15 @@
+(bug-step-subshell.sh:2):
+( echo inside subshell )
+(bug-step-subshell.sh:2):
+echo inside subshell
+Argument count is 0 for this call.
+Argument count is 0 for this call.
+zshdb<(5)>
+$? is 0
+inside subshell
+(bug-step-subshell.sh:3):
+echo out of subshell
+zshdb<6>
+$? is 0
+zshdb: That's all, folks...
+Debugged program terminated by user exit.

--- a/test/example/bug-step-subshell.sh
+++ b/test/example/bug-step-subshell.sh
@@ -1,0 +1,3 @@
+#!/bin/zsh
+(echo inside subshell)
+echo out of subshell

--- a/test/integration/.gitignore
+++ b/test/integration/.gitignore
@@ -12,6 +12,7 @@
 /test-bug-delete
 /test-bug-errexit
 /test-bug-ksharrays
+/test-bug-step-subshell
 /test-bugIFS
 /test-bugIFS2
 /test-condition

--- a/test/integration/Makefile.am
+++ b/test/integration/Makefile.am
@@ -7,6 +7,7 @@ TESTS = \
 	test-bugIFS2       \
 	test-bug-errexit   \
 	test-bug-ksharrays \
+	test-bug-step-subshell \
 	test-condition     \
 	test-debug         \
 	test-delete        \
@@ -45,6 +46,7 @@ SOURCES=check-common.sh.in \
 	test-bug-errexit.in \
 	test-bugIFS.in \
 	test-bug-ksharrays.in \
+	test-bug-step-subshell.in \
 	test-condition.in \
 	test-debug.in \
 	test-delete.in \

--- a/test/integration/test-bug-step-subshell.in
+++ b/test/integration/test-bug-step-subshell.in
@@ -1,0 +1,7 @@
+#!@SH_PROG@ -f
+# -*- shell-script -*-
+t=${0##*/}; TEST_NAME=$t[6,-1]   # basename $0 with 'test-' stripped off
+
+[ -z "$builddir" ] && builddir=$PWD
+. ${builddir}/check-common.sh
+run_test_check bug-step-subshell


### PR DESCRIPTION
This adds a (failing) test for issue https://github.com/rocky/zshdb/issues/58
Unfortunately I was unable to find a fix for this. bashdb seems to always rely on the history, but zshdb doesn't seem to record it always.