### PR TITLE
Prompt after subshell exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /*~
 /.idea
 /.python-version
+/.vscode
 /Makefile
 /Makefile.in
 /aclocal.m4

--- a/configure.ac
+++ b/configure.ac
@@ -118,6 +118,8 @@ AC_CONFIG_FILES([test/integration/test-bugIFS2],
                 [chmod +x test/integration/test-bugIFS2])
 AC_CONFIG_FILES([test/integration/test-bug-ksharrays],
                 [chmod +x test/integration/test-bug-ksharrays])
+AC_CONFIG_FILES([test/integration/test-bug-step-subshell],
+                [chmod +x test/integration/test-bug-step-subshell])
 AC_CONFIG_FILES([test/integration/test-condition],
                 [chmod +x test/integration/test-condition])
 AC_CONFIG_FILES([test/integration/test-debug],

--- a/lib/processor.sh
+++ b/lib/processor.sh
@@ -1,7 +1,7 @@
 # -*- shell-script -*-
 # dbg-processor.sh - Top-level debugger commands
 #
-#   Copyright (C) 2008, 2009, 2010, 2011, 2018, 2021, 2023
+#   Copyright (C) 2008, 2009, 2010, 2011, 2018, 2021, 2023-2024
 #   Rocky Bernstein <rocky@gnu.org>
 #
 #   This program is free software; you can redistribute it and/or
@@ -125,7 +125,9 @@ function _Dbg_process_commands {
               eval "_Dbg_prompt=\"$_Dbg_prompt_str \"" 2>/dev/null
 	  fi
 
-          ((_Dbg_cmd_num++))
+	  ((_Dbg_cmd_num++))
+          _Dbg_write_journal_eval "_Dbg_cmd_num=$_Dbg_cmd_num"
+
           if ((0 == _Dbg_in_vared)) && [[ -t $_Dbg_fdi ]]; then
               _Dbg_in_vared=1
               vared -e -h -p "$_Dbg_prompt" -t "$_Dbg_tty" line || break

--- a/test/data/bug-step-subshell.cmd
+++ b/test/data/bug-step-subshell.cmd
@@ -1,0 +1,10 @@
+# step into subshell
+step
+# execute commands inside subshell
+info args
+info args
+eval? echo \$_Dbg_prompt
+# step out of subshell
+step
+eval? echo \$_Dbg_prompt
+quit

--- a/test/data/bug-step-subshell.right
+++ b/test/data/bug-step-subshell.right
@@ -1,0 +1,15 @@
+(bug-step-subshell.sh:2):
+( echo inside subshell )
+(bug-step-subshell.sh:2):
+echo inside subshell
+Argument count is 0 for this call.
+Argument count is 0 for this call.
+zshdb<(5)>
+$? is 0
+inside subshell
+(bug-step-subshell.sh:3):
+echo out of subshell
+zshdb<6>
+$? is 0
+zshdb: That's all, folks...
+Debugged program terminated by user exit.

--- a/test/data/bug-step-subshell.right
+++ b/test/data/bug-step-subshell.right
@@ -9,7 +9,7 @@ $? is 0
 inside subshell
 (bug-step-subshell.sh:3):
 echo out of subshell
-zshdb<6>
+zshdb<8>
 $? is 0
 zshdb: That's all, folks...
 Debugged program terminated by user exit.

--- a/test/example/bug-step-subshell.sh
+++ b/test/example/bug-step-subshell.sh
@@ -1,0 +1,3 @@
+#!/bin/zsh
+(echo inside subshell)
+echo out of subshell

--- a/test/integration/.gitignore
+++ b/test/integration/.gitignore
@@ -12,6 +12,7 @@
 /test-bug-delete
 /test-bug-errexit
 /test-bug-ksharrays
+/test-bug-step-subshell
 /test-bugIFS
 /test-bugIFS2
 /test-condition

--- a/test/integration/Makefile.am
+++ b/test/integration/Makefile.am
@@ -7,6 +7,7 @@ TESTS = \
 	test-bugIFS2       \
 	test-bug-errexit   \
 	test-bug-ksharrays \
+	test-bug-step-subshell \
 	test-condition     \
 	test-debug         \
 	test-delete        \
@@ -45,6 +46,7 @@ SOURCES=check-common.sh.in \
 	test-bug-errexit.in \
 	test-bugIFS.in \
 	test-bug-ksharrays.in \
+	test-bug-step-subshell.in \
 	test-condition.in \
 	test-debug.in \
 	test-delete.in \

--- a/test/integration/test-bug-step-subshell.in
+++ b/test/integration/test-bug-step-subshell.in
@@ -1,0 +1,7 @@
+#!@SH_PROG@ -f
+# -*- shell-script -*-
+t=${0##*/}; TEST_NAME=$t[6,-1]   # basename $0 with 'test-' stripped off
+
+[ -z "$builddir" ] && builddir=$PWD
+. ${builddir}/check-common.sh
+run_test_check bug-step-subshell


### PR DESCRIPTION
Track debugger command number through subshells by saving the debug command number. 

Note that the test has something weird where commands are not showing up in output which is why we go from debug command 5 to 8 (6 and 7 output are not appearing). 