### PR TITLE
Go over some RST documentation

### DIFF
--- a/command/stepping.sh
+++ b/command/stepping.sh
@@ -65,6 +65,12 @@ Single step a statement without the \`step force' setting.
 Set step force may have been set on. step- ensures we turn that off for
 this command.
 
+Examples:
+---------
+
+    alias cat list   # "cat prog.py" is the same as "list prog.py"
+    alias s   step   # "s" is now an alias for "step".
+                     # The above example is done by default.
 See also:
 ---------
 

--- a/docs/commands/running/continue.rst
+++ b/docs/commands/running/continue.rst
@@ -1,7 +1,7 @@
 .. index:: continue
 .. _continue:
 
-Continue Program Execution (`continue`)
+Continue Program Execution (``continue``)
 ---------------------------------------
 
 **continue** [ *loc* | **-*** ]

--- a/docs/commands/running/debug.rst
+++ b/docs/commands/running/debug.rst
@@ -1,7 +1,7 @@
 .. index:: debug
 .. _debug:
 
-Recursive Debugging (`debug`)
+Recursive Debugging (``debug``)
 -----------------------------
 
 **debug** [*zsh-script* [*args*...]]

--- a/docs/commands/running/kill.rst
+++ b/docs/commands/running/kill.rst
@@ -1,7 +1,7 @@
 .. index:: kill
 .. _kill:
 
-Send Kill Signal (`kill`)
+Send Kill Signal (``kill``)
 -------------------------
 
 **kill** [ *signal-number* ]
@@ -38,3 +38,4 @@ Examples:
 .. seealso::
 
    :ref:`quit <quit>` for less a forceful termination command, :ref:`run <run>` restarts the debugged program.
+   Also similar is the `signal <signal>` command.

--- a/docs/commands/running/next.rst
+++ b/docs/commands/running/next.rst
@@ -1,22 +1,26 @@
 .. index:: next
 .. _next:
 
-Step Over (`next`)
+Step Over (``next``)
 ------------------
 
 **next** [ **+** | **-** ] [ *count* ]
 
 Step one statement ignoring steps into function calls at this level.
 
-With an integer argument, perform `next` that many times. However if
+With an integer argument, perform ``next`` that many times. However if
 an exception occurs at this level, or we *return*, *yield* or the
 thread changes, we stop regardless of count.
 
-A suffix of `+` on the command or an alias to the command forces to
-move to another line, while a suffix of `-` does the opposite and
+A suffix of ``+`` on the command or an alias to the command forces to
+move to another line, while a suffix of ``-`` does the opposite and
 disables the requiring a move to a new line. If no suffix is given,
 the debugger setting 'different-line' determines this behavior.
 
+Functions and source'd files are not traced. This is in contrast to
+``step``.
+
 .. seealso::
 
-   :ref:`skip <step>`, and :ref:`continue <continue>` provide other ways to progress execution.
+   :ref:`skip <skip>`, `step <step>`, and :ref:`continue <continue>` provide other ways to progress execution.
+   :ref:`set different <set_different>` sets the default stepping behavior.

--- a/docs/commands/running/quit.rst
+++ b/docs/commands/running/quit.rst
@@ -1,7 +1,7 @@
 .. index:: quit
 .. _quit:
 
-Gentle Termination (`quit`)
+Gentle Termination (``quit``)
 ---------------------------
 
 **quit** [*exit-code* [*shell-levels*]]

--- a/docs/commands/running/run.rst
+++ b/docs/commands/running/run.rst
@@ -1,7 +1,7 @@
 .. index:: run
 .. _run:
 
-Restart Program (`run`)
+Restart Program (``run``)
 -----------------------
 
 **run** [*args*]

--- a/docs/commands/running/skip.rst
+++ b/docs/commands/running/skip.rst
@@ -1,7 +1,7 @@
 .. index:: skip
 .. _skip:
 
-Skip over statement (`skip`)
+Skip over statement (``skip``)
 ----------------------------
 
 **skip** [ *count* ]

--- a/docs/commands/running/step.rst
+++ b/docs/commands/running/step.rst
@@ -4,41 +4,34 @@
 Step Into (`step`)
 ------------------
 
-**step** [ **+** | **-** | **<** | **>** | **!** ] [*event* ...] [ *count* ]
+**step** [ **+** | **-** [ *count* ]]
 
-Execute the current line, stopping at the next event.
+Single step a statement. This is sometimes called 'step into'.
 
-With an integer argument, step that many times.
+If *count* is given, stepping occurs that many times before
+stopping. Otherwise *count* is one. *count* an be an arithmetic
+expression.
 
-*event* is list of an event name which is one of: `call`,
-`return`, `line`, `exception` `c-call`, `c-return` or `c-exception`.
-If specified, only those stepping events will be considered. If no
-list of event names is given, then any event triggers a stop when the
-count is 0.
+If suffix \"+\" is added, we ensure that the file and line position is
+different from the last one just stopped at.
 
-There is however another way to specify a *single* event, by
-suffixing one of the symbols `<`, `>`, or `!` after the command or on
-an alias of that.  A suffix of `+` on a command or an alias forces a
-move to another line, while a suffix of `-` disables this requirement.
-A suffix of `>` will continue until the next call. (`finish` will run
-run until the return for that call.)
+However in contrast to \"next\", functions and source'd files are stepped
+into.
 
-If no suffix is given, the debugger setting `different-line`
-determines this behavior.
+If suffix \"-\" is added, the different line aspect of \"step+\" does not occur.
+
+With no suffix is given, the behavior is dictated by the setting of **set different**.
 
 Examples:
 +++++++++
 
 ::
 
-    step        # step 1 event, *any* event
+    step        # step 1
     step 1      # same as above
     step 5/5+0  # same as above
-    step line   # step only line events
-    step call   # step only call events
-    step>       # same as above
-    step call line # Step line *and* call events
 
 .. seealso::
 
    :ref:`next <next>` command. :ref:`skip <skip>`, and :ref:`continue <continue>` provide other ways to progress execution.
+    :ref:`set different <set_different>` sets the default stepping behavior.


### PR DESCRIPTION
* In RsT (in contrast to markdown) verbatim text has two backticks, not one. 
* Step documentation gone over. 