### PR TITLE
Support whitespace in installation directory and in script file names

### DIFF
--- a/command/break.sh
+++ b/command/break.sh
@@ -110,7 +110,7 @@ _Dbg_do_clear_brkpt() {
   typeset -i line_number
   typeset full_filename
 
-  if [[ -n $full_filename ]] ; then
+  if [[ -n "$full_filename" ]] ; then
     if (( line_number ==  0 )) ; then
       _Dbg_msg "There is no line 0 to clear."
     else

--- a/command/eval.sh
+++ b/command/eval.sh
@@ -20,7 +20,7 @@
 #   MA 02111 USA.
 
 # temp file for internal eval'd commands
-typeset _Dbg_evalfile=$(_Dbg_tempname eval)
+typeset _Dbg_evalfile="$(_Dbg_tempname eval)"
 
 # _Dbg_complete_level_1_data[eval?]=\
 #   '\$(typeset extracted; \
@@ -69,14 +69,14 @@ typeset -i _Dbg_show_eval_rc; _Dbg_show_eval_rc=1
 _Dbg_do_eval() {
 
     print "0=\"$_Dbg_dollar_0\"" > "$_Dbg_evalfile"
-    print ". ${_Dbg_libdir}/lib/set-d-vars.sh" >> "$_Dbg_evalfile"
+    print ". \"${_Dbg_libdir}/lib/set-d-vars.sh\"" >> "$_Dbg_evalfile"
     print '_Dbg_rc=$?' >> "$_Dbg_evalfile"
 
     if (( $# == 0 )) ; then
         # FIXME: add parameter to get unhighlighted line, or
         # always save a copy of that in _Dbg_sget_source_line
         typeset source_line
-        typeset highlight_save=$_Dbg_set_highlight
+        typeset highlight_save="$_Dbg_set_highlight"
         _Dbg_set_highlight=''
         _Dbg_get_source_line
         typeset source_line_save="$source_line"
@@ -93,7 +93,7 @@ _Dbg_do_eval() {
         # is just whether the the length of text of the the current is less
         # than the length of the full command in ZSH_DEBUG_CMD
         if (( ${#source_line} > ${#ZSH_DEBUG_CMD} )) ; then
-            source_line=$ZSH_DEBUG_CMD
+            source_line="$ZSH_DEBUG_CMD"
         fi
         if [[ '?' == "$suffix" ]] ; then
             typeset extracted
@@ -112,10 +112,10 @@ _Dbg_do_eval() {
     typeset -i _Dbg_rc
     if [[ -t $_Dbg_fdi  ]] ; then
         _Dbg_set_dol_q $_Dbg_debugged_exit_code
-        . $_Dbg_evalfile >&${_Dbg_fdi}
+        . "$_Dbg_evalfile" >&${_Dbg_fdi}
     else
         _Dbg_set_dol_q $_Dbg_debugged_exit_code
-        . $_Dbg_evalfile
+        . "$_Dbg_evalfile"
     fi
     _Dbg_rc=$?
     (( _Dbg_show_eval_rc )) && _Dbg_msg "\$? is $_Dbg_rc"

--- a/command/load.sh
+++ b/command/load.sh
@@ -37,11 +37,11 @@ _Dbg_do_load() {
     fi
 
     typeset filename="$1"
-    local full_filename=$(_Dbg_resolve_expand_filename "$filename")
+    local full_filename="$(_Dbg_resolve_expand_filename "$filename")"
     if [ -n "$full_filename" ] && [ -r "$full_filename" ] ; then
 	# Have we already loaded in this file?
-	for file in ${_Dbg_filenames[@]} ; do
-	    if [[ $file == $full_filename ]] ; then
+	for file in "${_Dbg_filenames[@]}" ; do
+	    if [[ "$file" == "$full_filename" ]] ; then
 		_Dbg_msg "File $full_filename already loaded."
 		return 2
 	    fi

--- a/dbg-pre.sh
+++ b/dbg-pre.sh
@@ -69,18 +69,18 @@ function _Dbg_expand_filename {
   typeset -x dirname="${filename%/*}"
 
   # No slash given in filename? Then use . for dirname
-  [[ $dirname == $basename ]] && [[ $filename != '/' ]] && dirname='.'
+  [[ "$dirname" == "$basename" ]] && [[ "$filename" != '/' ]] && dirname='.'
 
   # Dirname is ''? Then use / for dirname
-  dirname=${dirname:-/}
+  dirname="${dirname:-/}"
 
   # Handle tilde expansion in dirname
-  dirname=$(echo $dirname)
+  dirname="$(echo $dirname)"
 
   typeset long_path
 
-  [[ $basename == '.' ]] && basename=''
-  if long_path=$( (cd "$dirname" ; pwd) 2>/dev/null ) ; then
+  [[ "$basename" == '.' ]] && basename=''
+  if long_path="$( (cd "$dirname" ; pwd) 2>/dev/null )" ; then
     if [[ "$long_path" == '/' ]] ; then
       echo "/$basename"
     else
@@ -88,7 +88,7 @@ function _Dbg_expand_filename {
     fi
     return 0
   else
-    echo $filename
+    echo "$filename"
     return 1
   fi
 }
@@ -100,18 +100,18 @@ _Dbg_tempname() {
 }
 
 # Process command-line options
-. ${_Dbg_libdir}/dbg-opts.sh
+. "${_Dbg_libdir}/dbg-opts.sh"
 OPTLIND=1
 _Dbg_parse_options "$@"
 
-if [[ ! -d $_Dbg_tmpdir ]] && [[ ! -w $_Dbg_tmpdir ]] ; then
+if [[ ! -d "$_Dbg_tmpdir" ]] && [[ ! -w "$_Dbg_tmpdir" ]] ; then
   echo "${_Dbg_pname}: cannot write to temp directory $_Dbg_tmpdir." >&2
   echo "${_Dbg_pname}: Use -T try directory location." >&2
   exit 1
 fi
 
 # Save the initial working directory so we can reset it on a restart.
-typeset -x _Dbg_init_cwd=$PWD
+typeset -x _Dbg_init_cwd="$PWD"
 
 typeset -i _Dbg_running=1      # True we are not finished running the program
 
@@ -129,4 +129,4 @@ typeset -x _Dbg_space_IFS=$' \t\r\n'
 # debugger script to not stop in remaining debugger statements before
 # the sourcing the script to be debugged.
 typeset -i _Dbg_step_ignore=1
-[[ -n $_Dbg_histfile ]] && fc -p ${_Dbg_histfile}
+[[ -n "$_Dbg_histfile" ]] && fc -p "${_Dbg_histfile}"

--- a/zshdb.in
+++ b/zshdb.in
@@ -33,19 +33,19 @@ typeset _Dbg_release='@PACKAGE_VERSION@'
 typeset _Dbg_shell_name=${_Dbg_shell##*/}  # Equivalent to basename(_Dbg_shell)
 
 # Original $0. Note we can't set this in an include.
-typeset _Dbg_orig_0=$0
+typeset _Dbg_orig_0="$0"
 
 # Equivalent to basename $0; the short program name
-typeset _Dbg_pname=${0##*/}
+typeset _Dbg_pname="${0##*/}"
 
 ## Stuff set by autoconf/configure ###
-typeset  prefix=@prefix@  # @PKGDATADIR@ often uses $prefix
-typeset _Dbg_libdir=@PKGDATADIR@
+typeset  prefix="@prefix@"  # @PKGDATADIR@ often uses $prefix
+typeset _Dbg_libdir="@PKGDATADIR@"
 ###
 
 # We agonize a bit over _Dbg_libdir: the root directory for where
 # debugger code is stored. Below is just the first guess...
-[[ -d $_Dbg_libdir ]] || _Dbg_libdir='.'
+[[ -d "$_Dbg_libdir" ]] || _Dbg_libdir='.'
 
 # More _Dbg_libdir finding: respect any library option the user has
 # supplied over any of the above guesses. Go over options and parse
@@ -53,18 +53,18 @@ typeset _Dbg_libdir=@PKGDATADIR@
 local -a libdir
 zparseopts -a libdir -E L: -library:
 if (( ${#libdir} > 0 )) ; then
-    typeset -a lib_opts; eval "lib_opts=($libdir)"
-    if [[ ! -d ${lib_opts[2]} ]] ; then
+    typeset -a lib_opts; lib_opts=("${libdir[@]}")
+    if [[ ! -d "${lib_opts[2]}" ]] ; then
 	print "${lib_opts[2]} is not a directory" >&2
 	exit 1
     fi
-    _Dbg_libdir=${lib_opts[2]}
+    _Dbg_libdir="${lib_opts[2]}"
     unset lib_opts
 fi
 unset libdir
 
 # All _Dbg_libdir setting done above. Have we succeeded?
-if [[ ! -d $_Dbg_libdir ]] ; then
+if [[ ! -d "$_Dbg_libdir" ]] ; then
   echo "${_Dbg_pname}: Can't read debugger library directory '${_Dbg_libdir}'."
   echo "${_Dbg_pname}: Perhaps @PACKAGE@ is installed wrong (if its installed)." >&2
   echo "${_Dbg_pname}: Try running @PACKAGE@ using -L (with a different directory)." >&2
@@ -73,7 +73,7 @@ if [[ ! -d $_Dbg_libdir ]] ; then
 fi
 
 typeset _Dbg_main="$_Dbg_libdir/dbg-main.sh"
-if [[ ! -r $_Dbg_main ]] ; then
+if [[ ! -r "$_Dbg_main" ]] ; then
   print "${_Dbg_pname}: Can't read debugger library file '${_Dbg_main}'."
   print "${_Dbg_pname}: Perhaps @PACKAGE@ is installed wrong (if its installed)." >&2
   print "${_Dbg_pname}: Try running @PACKAGE@ using -L (with a different directory)." >&2
@@ -82,7 +82,7 @@ if [[ ! -r $_Dbg_main ]] ; then
 fi
 
 # Pull in the rest of the debugger code.
-. $_Dbg_main
+. "$_Dbg_main"
 
 _Dbg_set_debugger_entry
 
@@ -107,24 +107,24 @@ if [[ ! -r "$_Dbg_script_file" ]] ; then
   exit 1
 fi
 typeset _Dbg_source_file
-_Dbg_source_file=$(_Dbg_expand_filename "$_Dbg_script_file")
+_Dbg_source_file="$(_Dbg_expand_filename "$_Dbg_script_file")"
 
 # Directory in which the script is located
-typeset _Dbg_cdir=${_Dbg_source_file%/*}
+typeset _Dbg_cdir="${_Dbg_source_file%/*}"
 
-if ((_Dbg_set_history)) && [[ -r $_Dbg_histfile ]] ; then
-    fc -ap $_Dbg_histfile $_Dbg_history_length $_Dbg_history_length
+if ((_Dbg_set_history)) && [[ -r "$_Dbg_histfile" ]] ; then
+    fc -ap "$_Dbg_histfile" $_Dbg_history_length $_Dbg_history_length
 fi
 
 # Signal handling in zsh is different from bash.
 # zshdb/lib/sig.sh has some differences
 # _Dbg_init_default_traps
 
-if [[ -n $_Dbg_script_file ]] ; then
+if [[ -n "$_Dbg_script_file" ]] ; then
     # Set $0
-    0=$_Dbg_script_file
+    0="$_Dbg_script_file"
 fi
-typeset _Dbg_dollar_0=$0
+typeset _Dbg_dollar_0="$0"
 
 typeset -i _Dbg_is_running_program=1
 # trap 'echo ERR encountered inside debugger' ERR
@@ -138,4 +138,4 @@ trap '_Dbg_trap_handler $? "$0" "$@"
   255 ) return $_Dbg_return_rc ;;
   *   ) ;;
   esac' DEBUG
-. "$_Dbg_source_file" ${_Dbg_script_args[@]}
+. "$_Dbg_source_file" "${_Dbg_script_args[@]}"


### PR DESCRIPTION
I noticed issues when I tested zshdb on macOS, where paths like `/Library/Application Support/...` are common as installation directory. 
This PR fixes support for paths and filenames with whitespace to make it run on macOS for basic commands `load`, `break`, `eval`. I have not tested all commands.
Most likely, there will be more places like these to fix.

(Thank for the new release! I only tested yesterday after the release was mode ...)